### PR TITLE
Add Auth0 API authorization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:12-stretch
 RUN mkdir /app
 WORKDIR /app
 
-ARG API_HOST=https://dot.texastribune.org
+ARG APP_URL=https://dot.texastribune.org
 
 COPY package.json /app/
 COPY package-lock.json /app/

--- a/Makefile.dev
+++ b/Makefile.dev
@@ -23,7 +23,7 @@ dev: build net db
 
 build:
 	docker build \
-    --build-arg API_HOST=http://localhost:3000 \
+    --build-arg APP_URL=http://localhost:3000 \
    	--tag=${NS}/${APP} .
 
 net:

--- a/config.js
+++ b/config.js
@@ -4,31 +4,35 @@ const path = require('path');
 const IS_DEV = process.env.NODE_ENV === 'development';
 const PORT = parseInt(process.env.NODE_PORT, 10);
 
+const DASHBOARD_STATIC_ALIAS = '/static/';
 const DASHBOARD_MANIFEST_FILE_NAME = 'assets.json';
 const DASHBOARD_BUILD_PATH = path.join(process.cwd(), 'dist');
 const DASHBOARD_MANIFEST_PATH = path.join(
   DASHBOARD_BUILD_PATH,
   DASHBOARD_MANIFEST_FILE_NAME
 );
-const DASHBOARD_STATIC_ALIAS = '/static/';
 
 const TEMPLATES_PATH = path.join(process.cwd(), 'server', 'views');
-
 const PUBLIC_BUILD_PATH = path.join(process.cwd(), 'public');
 
 const { SENTRY_DSN, SENTRY_ENVIRONMENT } = process.env;
 const ENABLE_SENTRY = process.env.ENABLE_SENTRY === 'true';
 
+const { AUTH0_DOMAIN, AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET } = process.env;
+
 module.exports = {
   IS_DEV,
   PORT,
+  DASHBOARD_STATIC_ALIAS,
   DASHBOARD_MANIFEST_FILE_NAME,
   DASHBOARD_BUILD_PATH,
   DASHBOARD_MANIFEST_PATH,
-  DASHBOARD_STATIC_ALIAS,
   TEMPLATES_PATH,
   PUBLIC_BUILD_PATH,
   SENTRY_DSN,
   ENABLE_SENTRY,
   SENTRY_ENVIRONMENT,
+  AUTH0_DOMAIN,
+  AUTH0_CLIENT_ID,
+  AUTH0_CLIENT_SECRET,
 };

--- a/config.js
+++ b/config.js
@@ -18,7 +18,15 @@ const PUBLIC_BUILD_PATH = path.join(process.cwd(), 'public');
 const { SENTRY_DSN, SENTRY_ENVIRONMENT } = process.env;
 const ENABLE_SENTRY = process.env.ENABLE_SENTRY === 'true';
 
-const { AUTH0_DOMAIN, AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET } = process.env;
+const {
+  AUTH0_DOMAIN = 'auth-test.texastribune.org',
+  AUTH0_CLIENT_ID,
+  AUTH0_CLIENT_SECRET,
+  AUTH0_API_AUDIENCE = 'https://texastribune.org/dot',
+  AUTH0_JWT_ISSUER = `https://${AUTH0_DOMAIN}/`,
+  AUTH0_PUBLIC_KEY_URL = `https://${AUTH0_DOMAIN}/.well-known/jwks.json`,
+  AUTH0_JWT_ALGORITHM = 'RS256',
+} = process.env;
 
 module.exports = {
   IS_DEV,
@@ -35,4 +43,8 @@ module.exports = {
   AUTH0_DOMAIN,
   AUTH0_CLIENT_ID,
   AUTH0_CLIENT_SECRET,
+  AUTH0_API_AUDIENCE,
+  AUTH0_JWT_ISSUER,
+  AUTH0_PUBLIC_KEY_URL,
+  AUTH0_JWT_ALGORITHM,
 };

--- a/config.js
+++ b/config.js
@@ -29,6 +29,7 @@ const {
 const AUTH0_JWT_ISSUER = `https://${AUTH0_DOMAIN}/`;
 const AUTH0_PUBLIC_KEY_URL = `https://${AUTH0_DOMAIN}/.well-known/jwks.json`;
 const AUTH0_REDIRECT_URI = `${APP_URL}/logged-in/`;
+const AUTH0_TOKEN_URL = `https://${AUTH0_DOMAIN}/oauth/token`;
 
 module.exports = {
   APP_URL,
@@ -50,4 +51,5 @@ module.exports = {
   AUTH0_JWT_ISSUER,
   AUTH0_PUBLIC_KEY_URL,
   AUTH0_REDIRECT_URI,
+  AUTH0_TOKEN_URL,
 };

--- a/config.js
+++ b/config.js
@@ -1,6 +1,8 @@
 // eslint-disable-next-line
 const path = require('path');
 
+const { APP_URL } = process.env;
+
 const IS_DEV = process.env.NODE_ENV === 'development';
 const PORT = parseInt(process.env.NODE_PORT, 10);
 
@@ -23,12 +25,13 @@ const {
   AUTH0_CLIENT_ID,
   AUTH0_CLIENT_SECRET,
   AUTH0_API_AUDIENCE = 'https://texastribune.org/dot',
-  AUTH0_JWT_ISSUER = `https://${AUTH0_DOMAIN}/`,
-  AUTH0_PUBLIC_KEY_URL = `https://${AUTH0_DOMAIN}/.well-known/jwks.json`,
-  AUTH0_JWT_ALGORITHM = 'RS256',
 } = process.env;
+const AUTH0_JWT_ISSUER = `https://${AUTH0_DOMAIN}/`;
+const AUTH0_PUBLIC_KEY_URL = `https://${AUTH0_DOMAIN}/.well-known/jwks.json`;
+const AUTH0_REDIRECT_URI = `${APP_URL}/logged-in/`;
 
 module.exports = {
+  APP_URL,
   IS_DEV,
   PORT,
   DASHBOARD_STATIC_ALIAS,
@@ -46,5 +49,5 @@ module.exports = {
   AUTH0_API_AUDIENCE,
   AUTH0_JWT_ISSUER,
   AUTH0_PUBLIC_KEY_URL,
-  AUTH0_JWT_ALGORITHM,
+  AUTH0_REDIRECT_URI,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -195,6 +195,12 @@
       "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==",
       "dev": true
     },
+    "@types/auth0-js": {
+      "version": "9.12.4",
+      "resolved": "https://registry.npmjs.org/@types/auth0-js/-/auth0-js-9.12.4.tgz",
+      "integrity": "sha512-4r3OGEyRYb7r9lHd5TQ/9Mjszopv+JBC5c6Fb2lDfxc7PDFzIpSg9kD0l+4Kd6OmVwwWjqaBWCoqM8Clx/1Yig==",
+      "dev": true
+    },
     "@types/babel-types": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.7.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -212,7 +212,6 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
       "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
-      "dev": true,
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -228,7 +227,6 @@
       "version": "3.4.33",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
       "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -243,7 +241,6 @@
       "version": "4.17.6",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.6.tgz",
       "integrity": "sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==",
-      "dev": true,
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "*",
@@ -255,7 +252,6 @@
       "version": "0.0.42",
       "resolved": "https://registry.npmjs.org/@types/express-jwt/-/express-jwt-0.0.42.tgz",
       "integrity": "sha512-WszgUddvM1t5dPpJ3LhWNH8kfNN8GPIBrAGxgIYXVCEGx6Bx4A036aAuf/r5WH9DIEdlmp7gHOYvSM6U87B0ag==",
-      "dev": true,
       "requires": {
         "@types/express": "*",
         "@types/express-unless": "*"
@@ -265,7 +261,6 @@
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.4.tgz",
       "integrity": "sha512-dPs6CaRWxsfHbYDVU51VjEJaUJEcli4UI0fFMT4oWmgCvHj+j7oIxz5MLHVL0Rv++N004c21ylJNdWQvPkkb5w==",
-      "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/range-parser": "*"
@@ -275,7 +270,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/@types/express-unless/-/express-unless-0.5.1.tgz",
       "integrity": "sha512-5fuvg7C69lemNgl0+v+CUxDYWVPSfXHhJPst4yTLcqi4zKJpORCxnDrnnilk3k0DTq/WrAUdvXFs01+vUqUZHw==",
-      "dev": true,
       "requires": {
         "@types/express": "*"
       }
@@ -307,32 +301,27 @@
     "@types/mime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
-      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==",
-      "dev": true
+      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
     },
     "@types/node": {
       "version": "12.12.35",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.35.tgz",
-      "integrity": "sha512-ASYsaKecA7TUsDrqIGPNk3JeEox0z/0XR/WsJJ8BIX/9+SkMSImQXKWfU/yBrSyc7ZSE/NPqLu36Nur0miCFfQ==",
-      "dev": true
+      "integrity": "sha512-ASYsaKecA7TUsDrqIGPNk3JeEox0z/0XR/WsJJ8BIX/9+SkMSImQXKWfU/yBrSyc7ZSE/NPqLu36Nur0miCFfQ=="
     },
     "@types/qs": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.1.tgz",
-      "integrity": "sha512-lhbQXx9HKZAPgBkISrBcmAcMpZsmpe/Cd/hY7LGZS5OfkySUBItnPZHgQPssWYUET8elF+yCFBbP1Q0RZPTdaw==",
-      "dev": true
+      "integrity": "sha512-lhbQXx9HKZAPgBkISrBcmAcMpZsmpe/Cd/hY7LGZS5OfkySUBItnPZHgQPssWYUET8elF+yCFBbP1Q0RZPTdaw=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
-      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
-      "dev": true
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
     },
     "@types/serve-static": {
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz",
       "integrity": "sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==",
-      "dev": true,
       "requires": {
         "@types/express-serve-static-core": "*",
         "@types/mime": "*"
@@ -4121,6 +4110,35 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "jwks-rsa": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-1.8.0.tgz",
+      "integrity": "sha512-+HYROHD5fsYQCNrJ37RSr2NjbN2/V9YT+yVF3oJxLmPIZWrmp1SOl1hMw2RcuNh+LGA2bGZIhRKGiMjhQa/b7Q==",
+      "requires": {
+        "@types/express-jwt": "0.0.42",
+        "axios": "^0.19.2",
+        "debug": "^4.1.0",
+        "jsonwebtoken": "^8.5.1",
+        "limiter": "^1.1.4",
+        "lru-memoizer": "^2.0.1",
+        "ms": "^2.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "jws": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
@@ -4178,6 +4196,11 @@
         "type-check": "~0.3.2"
       }
     },
+    "limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
     "load-json-file": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -4229,6 +4252,11 @@
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -4307,6 +4335,26 @@
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
+      }
+    },
+    "lru-memoizer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.1.2.tgz",
+      "integrity": "sha512-N5L5xlnVcbIinNn/TJ17vHBZwBMt9t7aJDz2n97moWubjNl6VO9Ao2XuAGBBddkYdjrwR9HfzXbT6NfMZXAZ/A==",
+      "requires": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "~4.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+          "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
+          "requires": {
+            "pseudomap": "^1.0.1",
+            "yallist": "^2.0.0"
+          }
+        }
       }
     },
     "lru_map": {
@@ -5466,8 +5514,7 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "pstree.remy": {
       "version": "1.1.7",
@@ -8502,8 +8549,7 @@
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
       "version": "13.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,21 @@
         }
       }
     },
+    "@babel/runtime": {
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+      "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+        }
+      }
+    },
     "@sentry/apm": {
       "version": "5.15.4",
       "resolved": "https://registry.npmjs.org/@sentry/apm/-/apm-5.15.4.tgz",
@@ -236,6 +251,16 @@
         "@types/serve-static": "*"
       }
     },
+    "@types/express-jwt": {
+      "version": "0.0.42",
+      "resolved": "https://registry.npmjs.org/@types/express-jwt/-/express-jwt-0.0.42.tgz",
+      "integrity": "sha512-WszgUddvM1t5dPpJ3LhWNH8kfNN8GPIBrAGxgIYXVCEGx6Bx4A036aAuf/r5WH9DIEdlmp7gHOYvSM6U87B0ag==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*",
+        "@types/express-unless": "*"
+      }
+    },
     "@types/express-serve-static-core": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.4.tgz",
@@ -244,6 +269,24 @@
       "requires": {
         "@types/node": "*",
         "@types/range-parser": "*"
+      }
+    },
+    "@types/express-unless": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@types/express-unless/-/express-unless-0.5.1.tgz",
+      "integrity": "sha512-5fuvg7C69lemNgl0+v+CUxDYWVPSfXHhJPst4yTLcqi4zKJpORCxnDrnnilk3k0DTq/WrAUdvXFs01+vUqUZHw==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
+      }
+    },
+    "@types/graphql": {
+      "version": "14.5.0",
+      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.5.0.tgz",
+      "integrity": "sha512-MOkzsEp1Jk5bXuAsHsUi6BVv0zCO+7/2PTiZMXWDSsMXvNU6w/PLMQT2vHn8hy2i0JqojPz1Sz6rsFjHtsU0lA==",
+      "dev": true,
+      "requires": {
+        "graphql": "*"
       }
     },
     "@types/json-schema": {
@@ -648,6 +691,14 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@wry/equality": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz",
+      "integrity": "sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -822,6 +873,49 @@
         "picomatch": "^2.0.4"
       }
     },
+    "apollo-link": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
+      "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
+      "requires": {
+        "apollo-utilities": "^1.3.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3",
+        "zen-observable-ts": "^0.8.21"
+      }
+    },
+    "apollo-link-http-common": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.16.tgz",
+      "integrity": "sha512-2tIhOIrnaF4UbQHf7kjeQA/EmSorB7+HyJIIrUjJOKBgnXwuexi8aMecRlqTIDWcyVXCeqLhUnztMa6bOH/jTg==",
+      "requires": {
+        "apollo-link": "^1.2.14",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "apollo-upload-client": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/apollo-upload-client/-/apollo-upload-client-13.0.0.tgz",
+      "integrity": "sha512-lJ9/bk1BH1lD15WhWRha2J3+LrXrPIX5LP5EwiOUHv8PCORp4EUrcujrA3rI5hZeZygrTX8bshcuMdpqpSrvtA==",
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "apollo-link": "^1.2.12",
+        "apollo-link-http-common": "^0.2.14",
+        "extract-files": "^8.0.0"
+      }
+    },
+    "apollo-utilities": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.3.tgz",
+      "integrity": "sha512-F14aX2R/fKNYMvhuP2t9GD9fggID7zp5I96MF5QeKYWDWTrkRdHRp4+SVfXUVN+cXOaB/IebfvRtzPf25CM0zw==",
+      "requires": {
+        "@wry/equality": "^0.1.2",
+        "fast-json-stable-stringify": "^2.0.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.10.0"
+      }
+    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -948,17 +1042,35 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+    },
     "async-each": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "dev": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
+    },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
     },
     "babel-runtime": {
       "version": "6.26.0",
@@ -1225,6 +1337,11 @@
         "ieee754": "^1.1.4",
         "isarray": "^1.0.0"
       }
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -1576,6 +1693,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
     },
     "commander": {
       "version": "2.20.3",
@@ -1975,10 +2100,20 @@
         }
       }
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "deprecated-decorator": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz",
+      "integrity": "sha1-AJZjF7ehL+kvPMgx91g68ym4bDc="
     },
     "des.js": {
       "version": "1.0.1",
@@ -2069,6 +2204,14 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "ee-first": {
@@ -2677,6 +2820,63 @@
         "vary": "~1.1.2"
       }
     },
+    "express-graphql": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/express-graphql/-/express-graphql-0.9.0.tgz",
+      "integrity": "sha512-wccd9Lb6oeJ8yHpUs/8LcnGjFUUQYmOG9A5BNLybRdCzGw0PeUrtBxsIR8bfiur6uSW4OvPkVDoYH06z6/N9+w==",
+      "requires": {
+        "accepts": "^1.3.7",
+        "content-type": "^1.0.4",
+        "http-errors": "^1.7.3",
+        "raw-body": "^2.4.1"
+      },
+      "dependencies": {
+        "http-errors": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+          "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "raw-body": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
+          "integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
+          "requires": {
+            "bytes": "3.1.0",
+            "http-errors": "1.7.3",
+            "iconv-lite": "0.4.24",
+            "unpipe": "1.0.0"
+          }
+        }
+      }
+    },
+    "express-jwt": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/express-jwt/-/express-jwt-5.3.3.tgz",
+      "integrity": "sha512-UdB8p5O8vGYTKm3SfREnLgVGIGEHcL3lrVyi3ebEX2qhMuagN623ju7ywWis+qYL+CXE7G1qPc2bCPBAg2MxZQ==",
+      "requires": {
+        "async": "^1.5.0",
+        "express-unless": "^0.3.0",
+        "jsonwebtoken": "^8.1.0",
+        "lodash.set": "^4.0.0"
+      }
+    },
+    "express-unless": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/express-unless/-/express-unless-0.3.1.tgz",
+      "integrity": "sha1-JVfBRudb65A+LSR/m1ugFFJpbiA="
+    },
     "extend-shallow": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
@@ -2774,6 +2974,11 @@
         }
       }
     },
+    "extract-files": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-8.1.0.tgz",
+      "integrity": "sha512-PTGtfthZK79WUMk+avLmwx3NGdU8+iVFXC2NMGxKsn0MnihOG2lvumj+AZo8CTwTrwjXDgZ5tztbRlEdRjBonQ=="
+    },
     "fast-deep-equal": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
@@ -2783,8 +2988,7 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -2937,11 +3141,39 @@
         "readable-stream": "^2.3.6"
       }
     },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
+    },
+    "form-data": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
     },
     "forwarded": {
       "version": "0.1.2",
@@ -3135,6 +3367,36 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
       "dev": true
+    },
+    "graphql": {
+      "version": "14.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.6.0.tgz",
+      "integrity": "sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==",
+      "requires": {
+        "iterall": "^1.2.2"
+      }
+    },
+    "graphql-tools": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-5.0.0.tgz",
+      "integrity": "sha512-5zn3vtn//382b7G3Wzz3d5q/sh+f7tVrnxeuhTMTJ7pWJijNqLxH7VEzv8VwXCq19zAzHYEosFHfXiK7qzvk7w==",
+      "requires": {
+        "apollo-link": "^1.2.14",
+        "apollo-upload-client": "^13.0.0",
+        "deprecated-decorator": "^0.1.6",
+        "form-data": "^3.0.0",
+        "iterall": "^1.3.0",
+        "node-fetch": "^2.6.0",
+        "tslib": "^1.11.1",
+        "uuid": "^7.0.3"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
+        }
+      }
     },
     "has": {
       "version": "1.0.3",
@@ -3757,6 +4019,11 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "iterall": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
+    },
     "js-stringify": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
@@ -3811,6 +4078,30 @@
         "minimist": "^1.2.0"
       }
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "jstransformer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-1.0.0.tgz",
@@ -3818,6 +4109,25 @@
       "requires": {
         "is-promise": "^2.0.0",
         "promise": "^7.0.1"
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "keyv": {
@@ -3931,6 +4241,46 @@
       "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
       "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=",
       "dev": true
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
     "loglevel": {
       "version": "1.6.8",
@@ -4403,6 +4753,11 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-libs-browser": {
       "version": "2.2.1",
@@ -5732,8 +6087,7 @@
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "semver-diff": {
       "version": "3.1.1",
@@ -6509,6 +6863,14 @@
       "dev": true,
       "requires": {
         "nopt": "~1.0.10"
+      }
+    },
+    "ts-invariant": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
+      "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
+      "requires": {
+        "tslib": "^1.9.3"
       }
     },
     "ts-loader": {
@@ -8190,6 +8552,20 @@
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
+    },
+    "zen-observable": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
+    },
+    "zen-observable-ts": {
+      "version": "0.8.21",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
+      "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
+      "requires": {
+        "tslib": "^1.9.3",
+        "zen-observable": "^0.8.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "express-jwt": "^5.3.3",
     "graphql": "^14.6.0",
     "graphql-tools": "^5.0.0",
+    "jwks-rsa": "^1.8.0",
     "pug": "^2.0.4",
     "vue": "^2.6.11",
     "vuetify": "^2.2.21"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "vuetify": "^2.2.21"
   },
   "devDependencies": {
+    "@types/auth0-js": "^9.12.4",
     "@types/express": "^4.17.6",
     "@types/express-jwt": "0.0.42",
     "@types/graphql": "^14.5.0",

--- a/package.json
+++ b/package.json
@@ -18,14 +18,21 @@
   },
   "dependencies": {
     "@sentry/node": "^5.15.4",
+    "axios": "^0.19.2",
     "connect-slashes": "^1.4.0",
     "express": "^4.17.1",
+    "express-graphql": "^0.9.0",
+    "express-jwt": "^5.3.3",
+    "graphql": "^14.6.0",
+    "graphql-tools": "^5.0.0",
     "pug": "^2.0.4",
     "vue": "^2.6.11",
     "vuetify": "^2.2.21"
   },
   "devDependencies": {
     "@types/express": "^4.17.6",
+    "@types/express-jwt": "0.0.42",
+    "@types/graphql": "^14.5.0",
     "@types/node": "^12.12.35",
     "@types/webpack": "^4.41.11",
     "@types/webpack-dev-middleware": "^3.7.0",

--- a/server/app.ts
+++ b/server/app.ts
@@ -20,6 +20,7 @@ import {
 } from '../config';
 import routes from './routes';
 import logError from './utils/log-error';
+import { EnhancedError } from './errors';
 
 if (ENABLE_SENTRY) {
   Sentry.init({
@@ -49,8 +50,7 @@ app.get('/', (req, res) => {
 app.use(routes);
 app.use(
   (
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    error: any,
+    error: EnhancedError,
     req: express.Request,
     res: express.Response,
     next: express.NextFunction
@@ -64,15 +64,14 @@ app.use(
 app.use(
   '(/api*|/graph*)',
   (
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    error: any,
+    error: EnhancedError,
     req: express.Request,
     res: express.Response,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     next: express.NextFunction
   ) => {
     res.status(error.status || 500).json({
-      message: error.message || 'Unknown Error',
+      message: error.message,
       error: IS_DEV ? error : {},
     });
   }

--- a/server/app.ts
+++ b/server/app.ts
@@ -6,7 +6,6 @@ import express from 'express';
 import * as Sentry from '@sentry/node';
 import connectSlashes from 'connect-slashes';
 
-import routes from './routes';
 import webpackConfig from '../webpack.config';
 import {
   IS_DEV,
@@ -19,10 +18,8 @@ import {
   ENABLE_SENTRY,
   SENTRY_DSN,
 } from '../config';
-
-interface RouterError extends Error {
-  status?: number;
-}
+import routes from './routes';
+import logError from './utils/log-error';
 
 if (ENABLE_SENTRY) {
   Sentry.init({
@@ -46,26 +43,37 @@ if (IS_DEV) {
   app.use(webpackDev(webpack(webpackConfig as webpack.Configuration)));
 }
 
-// routes
 app.get('/', (req, res) => {
   res.redirect(302, '/dashboard');
 });
 app.use(routes);
-
-// error handlers
-app.use(Sentry.Handlers.errorHandler() as express.ErrorRequestHandler);
 app.use(
-  '/api',
   (
-    err: RouterError,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    error: any,
+    req: express.Request,
+    res: express.Response,
+    next: express.NextFunction
+  ) => {
+    if (!error.status || error.status >= 500) {
+      logError(error);
+    }
+    next(error);
+  }
+);
+app.use(
+  '(/api*|/graph*)',
+  (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    error: any,
     req: express.Request,
     res: express.Response,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     next: express.NextFunction
   ) => {
-    res.status(err.status || 500).json({
-      message: err.message,
-      error: IS_DEV ? err : {},
+    res.status(error.status || 500).json({
+      message: error.message || 'Unknown Error',
+      error: IS_DEV ? error : {},
     });
   }
 );

--- a/server/errors.ts
+++ b/server/errors.ts
@@ -1,7 +1,13 @@
+/* eslint-disable max-classes-per-file */
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyObject = { [key: string]: any };
 
-export default class AppError extends Error {
+export interface EnhancedError extends Error {
+  status?: number;
+}
+
+export abstract class AppError extends Error implements EnhancedError {
   public status: number;
 
   public extra?: AnyObject;
@@ -22,5 +28,25 @@ export default class AppError extends Error {
     this.name = name;
     this.status = status;
     this.extra = extra;
+  }
+}
+
+export class UnauthorizedError extends AppError {
+  constructor({ message, extra }: { message: string; extra?: AnyObject }) {
+    super({ message, extra, status: 401, name: 'UnauthorizedError' });
+  }
+}
+
+export class PublicKeyError extends AppError {
+  constructor({
+    message,
+    status,
+    extra,
+  }: {
+    message: string;
+    status: number;
+    extra?: AnyObject;
+  }) {
+    super({ message, status, extra, name: 'PublicKeyError' });
   }
 }

--- a/server/errors.ts
+++ b/server/errors.ts
@@ -1,3 +1,5 @@
+/* eslint-disable max-classes-per-file */
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyObject = { [key: string]: any };
 
@@ -6,13 +8,33 @@ export default class AppError extends Error {
 
   public extra?: AnyObject;
 
-  constructor(message: string, status: number, extra?: AnyObject) {
+  constructor({
+    message,
+    name,
+    status = 500,
+    extra = {},
+  }: {
+    message: string;
+    name: string;
+    status?: number;
+    extra?: AnyObject;
+  }) {
     super(message);
 
+    this.name = name;
     this.status = status;
+    this.extra = extra;
+  }
+}
 
-    if (extra) {
-      this.extra = extra;
-    }
+export class PublicKeyError extends AppError {
+  constructor({ message, extra }: { message: string; extra?: AnyObject }) {
+    super({ message, name: 'PublicKeyError', extra });
+  }
+}
+
+export class UnauthorizedError extends AppError {
+  constructor({ message, extra }: { message: string; extra?: AnyObject }) {
+    super({ message, name: 'UnauthorizedError', status: 401, extra });
   }
 }

--- a/server/errors.ts
+++ b/server/errors.ts
@@ -15,12 +15,12 @@ export abstract class AppError extends Error implements EnhancedError {
   constructor({
     message,
     name,
-    status = 500,
+    status,
     extra = {},
   }: {
     message: string;
     name: string;
-    status?: number;
+    status: number;
     extra?: AnyObject;
   }) {
     super(message);
@@ -34,6 +34,20 @@ export abstract class AppError extends Error implements EnhancedError {
 export class UnauthorizedError extends AppError {
   constructor({ message, extra }: { message: string; extra?: AnyObject }) {
     super({ message, extra, status: 401, name: 'UnauthorizedError' });
+  }
+}
+
+export class TokenRetrievalError extends AppError {
+  constructor({
+    message,
+    status = 500,
+    extra,
+  }: {
+    message: string;
+    status?: number;
+    extra?: AnyObject;
+  }) {
+    super({ message, status, extra, name: 'TokenRetrievalError' });
   }
 }
 

--- a/server/errors.ts
+++ b/server/errors.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-classes-per-file */
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyObject = { [key: string]: any };
 
@@ -24,17 +22,5 @@ export default class AppError extends Error {
     this.name = name;
     this.status = status;
     this.extra = extra;
-  }
-}
-
-export class PublicKeyError extends AppError {
-  constructor({ message, extra }: { message: string; extra?: AnyObject }) {
-    super({ message, name: 'PublicKeyError', extra });
-  }
-}
-
-export class UnauthorizedError extends AppError {
-  constructor({ message, extra }: { message: string; extra?: AnyObject }) {
-    super({ message, name: 'UnauthorizedError', status: 401, extra });
   }
 }

--- a/server/routes/api/v1/index.ts
+++ b/server/routes/api/v1/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import express from 'express';
 
 import {
@@ -9,6 +9,7 @@ import {
   AUTH0_REDIRECT_URI,
   AUTH0_TOKEN_URL,
 } from '../../../../config';
+import { TokenRetrievalError } from '../../../errors';
 
 const router = express.Router();
 
@@ -16,7 +17,7 @@ router.get('/tokens', async (req, res, next) => {
   const { code } = req.query;
 
   try {
-    const { data } = await axios.post(AUTH0_TOKEN_URL, {
+    const { data } = await axios.post<auth0.Auth0Result>(AUTH0_TOKEN_URL, {
       code,
       client_id: AUTH0_CLIENT_ID,
       client_secret: AUTH0_CLIENT_SECRET,
@@ -24,9 +25,36 @@ router.get('/tokens', async (req, res, next) => {
       redirect_uri: AUTH0_REDIRECT_URI,
     });
 
-    res.json({ tokens: data });
-  } catch (err) {
-    next(err);
+    return res.json({ tokens: data });
+  } catch (error) {
+    if (error.isAxiosError) {
+      const axiosError: AxiosError<auth0.Auth0Error> = error;
+      const { response } = axiosError;
+
+      if (
+        response &&
+        response.data.error_description === 'Invalid authorization code'
+      ) {
+        return next(
+          new TokenRetrievalError({
+            message: 'Invalid authorization code',
+            status: 403,
+          })
+        );
+      }
+
+      return next(
+        new TokenRetrievalError({
+          message: 'Error retrieving authorization token',
+          extra: {
+            error,
+            data: response ? response.data : null,
+          },
+        })
+      );
+    }
+
+    return next(error);
   }
 });
 

--- a/server/routes/api/v1/index.ts
+++ b/server/routes/api/v1/index.ts
@@ -1,9 +1,33 @@
+/* eslint-disable @typescript-eslint/camelcase */
+
+import axios from 'axios';
 import express from 'express';
+
+import {
+  AUTH0_CLIENT_ID,
+  AUTH0_CLIENT_SECRET,
+  AUTH0_REDIRECT_URI,
+  AUTH0_TOKEN_URL,
+} from '../../../../config';
 
 const router = express.Router();
 
-router.get('/test', (req, res) => {
-  res.json({ foo: 'bar' });
+router.get('/tokens', async (req, res, next) => {
+  const { code } = req.query;
+
+  try {
+    const { data } = await axios.post(AUTH0_TOKEN_URL, {
+      code,
+      client_id: AUTH0_CLIENT_ID,
+      client_secret: AUTH0_CLIENT_SECRET,
+      grant_type: 'authorization_code',
+      redirect_uri: AUTH0_REDIRECT_URI,
+    });
+
+    res.json({ tokens: data });
+  } catch (err) {
+    next(err);
+  }
 });
 
 export default router;

--- a/server/routes/graph/index.ts
+++ b/server/routes/graph/index.ts
@@ -1,53 +1,30 @@
 import express from 'express';
 import graphql from 'express-graphql';
 import jwt from 'express-jwt';
+import jwksRsa from 'jwks-rsa';
 import { makeExecutableSchema } from 'graphql-tools';
-import axios, { AxiosError } from 'axios';
 
-import { IS_DEV, AUTH0_DOMAIN, AUTH0_CLIENT_ID } from '../../../config';
-import { PublicKeyError, UnauthorizedError } from '../../errors';
+import {
+  IS_DEV,
+  AUTH0_API_AUDIENCE,
+  AUTH0_JWT_ISSUER,
+  AUTH0_PUBLIC_KEY_URL,
+  AUTH0_JWT_ALGORITHM,
+} from '../../../config';
+import AppError from '../../errors';
 import typeDefs from './types';
 import resolvers from './resolvers';
 
-interface PublicKey {
-  alg: string;
-  kty: string;
-  use: string;
-  n: string;
-  e: string;
-  kid: string;
-  x5t: string;
-  x5c: string[];
-}
-
-const PUBLIC_KEY_URL = `https://${AUTH0_DOMAIN}/.well-known/jwks.json`;
-const JWT_ISSUER = `https://${AUTH0_DOMAIN}/`;
-const JWT_AUDIENCE = AUTH0_CLIENT_ID;
-
 const router = express.Router();
-
-const getPublicKey: jwt.SecretCallback = (req, payload, done): void => {
-  axios
-    .get<{ keys: PublicKey[] }>(PUBLIC_KEY_URL)
-    .then(({ data: publicKey }) => {
-      done(null, JSON.stringify(publicKey));
-    })
-    .catch((error) => {
-      const axiosError: AxiosError<PublicKey[]> = error;
-      done(
-        new PublicKeyError({
-          message: axiosError.message,
-          extra: axiosError.toJSON(),
-        })
-      );
-    });
-};
 
 router.use(
   jwt({
-    secret: getPublicKey,
-    audience: JWT_AUDIENCE,
-    issuer: JWT_ISSUER,
+    secret: jwksRsa.expressJwtSecret({
+      jwksUri: AUTH0_PUBLIC_KEY_URL,
+    }),
+    algorithms: [AUTH0_JWT_ALGORITHM],
+    audience: AUTH0_API_AUDIENCE,
+    issuer: AUTH0_JWT_ISSUER,
   }),
   graphql({
     schema: makeExecutableSchema({ typeDefs, resolvers }),
@@ -57,16 +34,32 @@ router.use(
 
 router.use(
   (
-    error: Error,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    error: any,
     req: express.Request,
     res: express.Response,
     next: express.NextFunction
   ) => {
-    if (error.name === 'UnauthorizedError') {
-      next(new UnauthorizedError({ message: error.message }));
-    } else {
-      next(error);
+    if (error instanceof Error) {
+      let status = 500;
+      const { message, name } = error;
+
+      if (error instanceof jwt.UnauthorizedError) {
+        status = 401;
+      } else if (error instanceof jwksRsa.ArgumentError) {
+        status = 500;
+      } else if (error instanceof jwksRsa.JwksError) {
+        status = 500;
+      } else if (error instanceof jwksRsa.SigningKeyNotFoundError) {
+        status = 500;
+      } else if (error instanceof jwksRsa.JwksRateLimitError) {
+        status = 429;
+      }
+
+      return next(new AppError({ message, name, status }));
     }
+
+    return next(error);
   }
 );
 

--- a/server/routes/graph/index.ts
+++ b/server/routes/graph/index.ts
@@ -1,0 +1,73 @@
+import express from 'express';
+import graphql from 'express-graphql';
+import jwt from 'express-jwt';
+import { makeExecutableSchema } from 'graphql-tools';
+import axios, { AxiosError } from 'axios';
+
+import { IS_DEV, AUTH0_DOMAIN, AUTH0_CLIENT_ID } from '../../../config';
+import { PublicKeyError, UnauthorizedError } from '../../errors';
+import typeDefs from './types';
+import resolvers from './resolvers';
+
+interface PublicKey {
+  alg: string;
+  kty: string;
+  use: string;
+  n: string;
+  e: string;
+  kid: string;
+  x5t: string;
+  x5c: string[];
+}
+
+const PUBLIC_KEY_URL = `https://${AUTH0_DOMAIN}/.well-known/jwks.json`;
+const JWT_ISSUER = `https://${AUTH0_DOMAIN}/`;
+const JWT_AUDIENCE = AUTH0_CLIENT_ID;
+
+const router = express.Router();
+
+const getPublicKey: jwt.SecretCallback = (req, payload, done): void => {
+  axios
+    .get<{ keys: PublicKey[] }>(PUBLIC_KEY_URL)
+    .then(({ data: publicKey }) => {
+      done(null, JSON.stringify(publicKey));
+    })
+    .catch((error) => {
+      const axiosError: AxiosError<PublicKey[]> = error;
+      done(
+        new PublicKeyError({
+          message: axiosError.message,
+          extra: axiosError.toJSON(),
+        })
+      );
+    });
+};
+
+router.use(
+  jwt({
+    secret: getPublicKey,
+    audience: JWT_AUDIENCE,
+    issuer: JWT_ISSUER,
+  }),
+  graphql({
+    schema: makeExecutableSchema({ typeDefs, resolvers }),
+    graphiql: IS_DEV,
+  })
+);
+
+router.use(
+  (
+    error: Error,
+    req: express.Request,
+    res: express.Response,
+    next: express.NextFunction
+  ) => {
+    if (error.name === 'UnauthorizedError') {
+      next(new UnauthorizedError({ message: error.message }));
+    } else {
+      next(error);
+    }
+  }
+);
+
+export default router;

--- a/server/routes/graph/index.ts
+++ b/server/routes/graph/index.ts
@@ -9,7 +9,6 @@ import {
   AUTH0_API_AUDIENCE,
   AUTH0_JWT_ISSUER,
   AUTH0_PUBLIC_KEY_URL,
-  AUTH0_JWT_ALGORITHM,
 } from '../../../config';
 import { EnhancedError, UnauthorizedError, PublicKeyError } from '../../errors';
 import typeDefs from './types';
@@ -22,7 +21,7 @@ router.use(
     secret: jwksRsa.expressJwtSecret({
       jwksUri: AUTH0_PUBLIC_KEY_URL,
     }),
-    algorithms: [AUTH0_JWT_ALGORITHM],
+    algorithms: ['RS256'],
     audience: AUTH0_API_AUDIENCE,
     issuer: AUTH0_JWT_ISSUER,
   }),

--- a/server/routes/graph/resolvers.ts
+++ b/server/routes/graph/resolvers.ts
@@ -3,7 +3,6 @@
 const resolvers = {
   Query: {
     posts(root: any, args: any, request: any): string[] {
-      console.log(request.user);
       return ['foo', 'bar'];
     },
   },

--- a/server/routes/graph/resolvers.ts
+++ b/server/routes/graph/resolvers.ts
@@ -3,6 +3,12 @@
 const resolvers = {
   Query: {
     posts(root: any, args: any, request: any): string[] {
+      if (request.user.permissions.includes('dot:view_data')) {
+        console.log('you are allowed here :)');
+      } else {
+        console.log('you are NOT allowed here :(');
+      }
+
       return ['foo', 'bar'];
     },
   },

--- a/server/routes/graph/resolvers.ts
+++ b/server/routes/graph/resolvers.ts
@@ -1,0 +1,12 @@
+/* eslint-disable */
+
+const resolvers = {
+  Query: {
+    posts(root: any, args: any, request: any): string[] {
+      console.log(request.user);
+      return ['foo', 'bar'];
+    },
+  },
+};
+
+export default resolvers;

--- a/server/routes/graph/types.ts
+++ b/server/routes/graph/types.ts
@@ -1,0 +1,7 @@
+const typeDefs = `
+  type Query {
+    posts: [String!]!
+  }
+`;
+
+export default typeDefs;

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -1,13 +1,17 @@
 import express from 'express';
 
 import apiRoutes from './api';
-import graphRoutes from './graph';
 import dashboardRoutes from './dashboard';
+import graphRoutes from './graph';
+import logIn from './log-in';
+import loggedIn from './logged-in';
 
 const router = express.Router();
 
 router.use('/api', apiRoutes);
-router.use('/graph', graphRoutes);
 router.use('/dashboard', dashboardRoutes);
+router.use('/graph', graphRoutes);
+router.use('/log-in', logIn);
+router.use('/logged-in', loggedIn);
 
 export default router;

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -1,11 +1,13 @@
 import express from 'express';
 
 import apiRoutes from './api';
+import graphRoutes from './graph';
 import dashboardRoutes from './dashboard';
 
 const router = express.Router();
 
 router.use('/api', apiRoutes);
+router.use('/graph', graphRoutes);
 router.use('/dashboard', dashboardRoutes);
 
 export default router;

--- a/server/routes/log-in/index.ts
+++ b/server/routes/log-in/index.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+
+const router = express.Router();
+
+router.get('/', (req, res) => {
+  res.render('log-in');
+});
+
+export default router;

--- a/server/routes/logged-in/index.ts
+++ b/server/routes/logged-in/index.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+
+const router = express.Router();
+
+router.get('/', (req, res) => {
+  res.render('logged-in');
+});
+
+export default router;

--- a/server/utils/log-error.ts
+++ b/server/utils/log-error.ts
@@ -2,13 +2,6 @@ import { captureException, withScope } from '@sentry/node';
 
 import AppError from '../errors';
 
-class UnknownError extends Error {
-  constructor() {
-    super('Malformed JavaScript error');
-    this.name = 'UnknownError';
-  }
-}
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default function logError(error: any): void {
   withScope((scope) => {
@@ -20,10 +13,6 @@ export default function logError(error: any): void {
       scope.setExtra('extra', error.extra);
     }
 
-    if (error instanceof Error) {
-      captureException(error);
-    } else {
-      captureException(new UnknownError());
-    }
+    captureException(error);
   });
 }

--- a/server/utils/log-error.ts
+++ b/server/utils/log-error.ts
@@ -1,9 +1,8 @@
 import { captureException, withScope } from '@sentry/node';
 
-import AppError from '../errors';
+import { AppError, EnhancedError } from '../errors';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default function logError(error: any): void {
+export default function logError(error: EnhancedError): void {
   withScope((scope) => {
     if (error.status) {
       scope.setExtra('status', error.status);

--- a/server/views/log-in.pug
+++ b/server/views/log-in.pug
@@ -1,0 +1,24 @@
+doctype html
+html
+  head
+    title Logged In
+    meta(
+      name='viewport',
+      content='width=device-width, initial-scale=1.0'
+    )
+
+  body
+    h1 Log in
+
+  script(src='https://cdn.auth0.com/js/auth0/9.13.2/auth0.min.js')
+  script.
+    const auth = new auth0.WebAuth({
+      domain: 'auth-test.texastribune.org',
+      clientID: 'YQ7ktxaQjg0SJ4m2yMylVdF1N7KSgoqg',
+      redirectUri: 'http://localhost:3000/logged-in/',
+      responseType: 'code',
+      responseMode: 'query',
+      audience: 'https://texastribune.org/dot'
+    });
+
+    auth.authorize();

--- a/server/views/logged-in.pug
+++ b/server/views/logged-in.pug
@@ -1,0 +1,20 @@
+doctype html
+html
+  head
+    title Logged In
+    meta(
+      name='viewport',
+      content='width=device-width, initial-scale=1.0'
+    )
+
+  body
+    h1 You're logged in!
+
+  script(src='https://unpkg.com/axios/dist/axios.min.js')
+  script.
+    const urlParams = new URLSearchParams(window.location.search);
+    const code = urlParams.get('code');
+
+    axios.get(`/api/v1/tokens/?code=${code}`).then(data => {
+      console.log(data);
+    });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,7 @@ const config = {
 
   plugins: [
     new VueLoaderPlugin(),
-    new EnvironmentPlugin(['API_HOST', 'NODE_ENV']),
+    new EnvironmentPlugin(['APP_URL', 'NODE_ENV']),
     new WebpackAssetsManifest({
       entrypoints: true,
       output: DASHBOARD_MANIFEST_FILE_NAME,


### PR DESCRIPTION
#### What's this PR do?
Adds the ability to allow certain GraphQL queries and mutations only to be accessible to certain staff members. This is done by verifying the permissions on access tokens granted by Auth0 and registering the Dot API inside our Auth0 tenants.

Also improves error handling.

#### Why are we doing this? How does it help us?
The API behind this app should only be callable by staff members, for obvious reasons. And having this very explicit `dot:view_data` permission inside Auth0 means we can limit access even more granularly.

#### How should this be manually tested?
Add the following to your `env-docker`:
```
DB_HOST=dot-db
DB_USER=postgres
DB_PASSWORD=postgres
DB_NAME=dot
DB_PORT=5432
NODE_PORT=3000
APP_URL=http://localhost:3000
AUTH0_DOMAIN=auth-test.texastribune.org
AUTH0_API_AUDIENCE=https://texastribune.org/dot
AUTH0_CLIENT_ID=YQ7ktxaQjg0SJ4m2yMylVdF1N7KSgoqg
AUTH0_CLIENT_SECRET=[get from Auth0 test tenant under Applications --> Dot]
```
Then:
1. `make -f Makefile.dev`
2. `npm start`
3. Go to `http://localhost:3000/log-in/`. You'll be asked to log in and/or authorize access to the Dot app. Do that!
4. You should get redirected to another page. Open your browser console and unfold the object logged there until you find your access token (`data.tokens.access_token`). Copy it (don't include the beginning and end double quote).
5. Throw your token in [this website](https://jwt.io/) and confirm the `permissions` key of the decoded token is an empty array.
6. Execute the below cURL command in a new terminal window, replacing `<access token>` with yours. You should get back some `foo bar` JSON, but the terminal you're running `npm start` in should have a message about you not being allowed there.
7. In the Auth0 dashboard, inside the **test tenant**, go to Users & Roles --> Users (on the left). Find yourself, go to the Permissions tab, click Assign Permissions, click Dot API, then give yourself `dot:view_data` permissions.
8. Repeat steps 3-6. In step 5, the permissions array should now contain `dot:view_data`. In step 6, the message logged to your `npm start` console should say that you **are** allowed there.

```
curl \
  -X POST \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer <access token>" \
  --data '{ "query": "{ posts }" }' \
  http://localhost:3000/graph/
```

#### How should this change be communicated to end users?
NA.

#### Are there any smells or added technical debt to note?
Nope! I think this is the clean, right way to do API authorization with Auth0. 

#### What are the relevant tickets?
https://3.basecamp.com/3098728/buckets/736178/todos/2545308227

#### Have you done the following, if applicable:
- [ ] Added automated tests?
- [ ] Tested manually on mobile?
- [ ] Checked BrowserStack?
- [ ] Checked for performance implications?
- [ ] Checked accessibility?
- [x] Checked for security implications?
- [ ] Updated the documentation/wiki?