### PR TITLE
use alpine docker base image; simplify entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ COPY . /app/
 
 RUN npm run build
 
-ENTRYPOINT ["/app/shell/docker-entrypoint.sh"]
+ENTRYPOINT ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-stretch
+FROM node:12-alpine
 
 RUN mkdir /app
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:12-alpine
 
+# add bash for dev
+RUN apk add --no-cache bash
+
 RUN mkdir /app
 WORKDIR /app
 

--- a/shell/docker-entrypoint.sh
+++ b/shell/docker-entrypoint.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-npm start


### PR DESCRIPTION
This PR reduces the docker build from 1.16gb to 346mb by switching our base image from a full `stretch` os base to use node's [`alpine` base](https://nickjanetakis.com/blog/the-3-biggest-wins-when-using-alpine-as-a-base-docker-image), which will help make our builds quicker.

Also makes a small change to the entrypoint to call `npm start` directly instead of putting it in an external `.sh` file.