### PR TITLE
Remove TypeScript reference types; use alternate dynamic-slot syntax

### DIFF
--- a/dashboard/App.vue
+++ b/dashboard/App.vue
@@ -1,9 +1,4 @@
 <script lang="ts">
-/* eslint-disable @typescript-eslint/triple-slash-reference, spaced-comment */
-/// <reference path="../node_modules/vuetify/types/lib.d.ts" />
-// eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
-/// <reference path="../node_modules/vue-meta/types/vue.d.ts" />
-
 import Vue from 'vue';
 import { mapActions, mapGetters } from 'vuex';
 import { VApp, VAppBar, VOverlay } from 'vuetify/lib';

--- a/dashboard/ErrorView.vue
+++ b/dashboard/ErrorView.vue
@@ -1,9 +1,4 @@
 <script lang="ts">
-// eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
-/// <reference path="../node_modules/vue-meta/types/vue.d.ts" />
-/* eslint-disable @typescript-eslint/triple-slash-reference, spaced-comment */
-/// <reference path="../node_modules/vuetify/types/lib.d.ts" />
-
 import Vue from 'vue';
 import { mapGetters } from 'vuex';
 import { VMain, VContainer, VRow, VCol } from 'vuetify/lib';

--- a/dashboard/components/LoadingWheel.vue
+++ b/dashboard/components/LoadingWheel.vue
@@ -1,7 +1,4 @@
 <script lang="ts">
-/* eslint-disable @typescript-eslint/triple-slash-reference, spaced-comment */
-/// <reference path="../../node_modules/vuetify/types/lib.d.ts" />
-
 import Vue from 'vue';
 import { VProgressCircular } from 'vuetify/lib';
 

--- a/dashboard/components/ViewsTable.vue
+++ b/dashboard/components/ViewsTable.vue
@@ -1,7 +1,4 @@
 <script lang="ts">
-/* eslint-disable vue/valid-v-slot, @typescript-eslint/triple-slash-reference, spaced-comment */
-/// <reference path="../../node_modules/vuetify/types/lib.d.ts" />
-
 import Vue, { PropType } from 'vue';
 import { VDataTable, VTextField } from 'vuetify/lib';
 import { DataTableHeader } from 'vuetify';
@@ -120,11 +117,11 @@ export default Vue.extend({
       </form>
 
       <v-data-table :headers="headers" :items="items" :search="search">
-        <template #item.content="{ item: { content } }">
+        <template v-slot:[`item.content`]="{ item: { content } }">
           <slot name="content" :content="content"></slot>
         </template>
 
-        <template #item.views="{ item: { views } }">
+        <template v-slot:[`item.views`]="{ item: { views } }">
           <span>{{ formatViews(views) }}</span>
         </template>
       </v-data-table>

--- a/dashboard/routes/canonical-detail/Index.vue
+++ b/dashboard/routes/canonical-detail/Index.vue
@@ -1,9 +1,4 @@
 <script lang="ts">
-/* eslint-disable vue/valid-v-slot, @typescript-eslint/triple-slash-reference, spaced-comment */
-/// <reference path="../../../node_modules/vue-apollo/types/vue.d.ts" />
-/* eslint-disable vue/valid-v-slot, @typescript-eslint/triple-slash-reference, spaced-comment */
-/// <reference path="../../../node_modules/vue-meta/types/vue.d.ts" />
-
 import Vue from 'vue';
 import { DataTableHeader } from 'vuetify';
 import { MetaInfo } from 'vue-meta';

--- a/dashboard/routes/domain-detail/Index.vue
+++ b/dashboard/routes/domain-detail/Index.vue
@@ -1,9 +1,4 @@
 <script lang="ts">
-/* eslint-disable vue/valid-v-slot, @typescript-eslint/triple-slash-reference, spaced-comment */
-/// <reference path="../../../node_modules/vue-apollo/types/vue.d.ts" />
-/* eslint-disable vue/valid-v-slot, @typescript-eslint/triple-slash-reference, spaced-comment */
-/// <reference path="../../../node_modules/vue-meta/types/vue.d.ts" />
-
 import Vue from 'vue';
 import { DataTableHeader } from 'vuetify';
 import { MetaInfo } from 'vue-meta';

--- a/dashboard/routes/logged-in/Index.vue
+++ b/dashboard/routes/logged-in/Index.vue
@@ -1,7 +1,4 @@
 <script lang="ts">
-/* eslint-disable @typescript-eslint/triple-slash-reference, spaced-comment */
-/// <reference path="../../../node_modules/vuetify/types/lib.d.ts" />
-
 import Vue from 'vue';
 import { mapActions } from 'vuex';
 import VueRouter, { Route } from 'vue-router';

--- a/dashboard/routes/main/Index.vue
+++ b/dashboard/routes/main/Index.vue
@@ -1,7 +1,4 @@
 <script lang="ts">
-/* eslint-disable @typescript-eslint/triple-slash-reference, spaced-comment */
-/// <reference path="../../../node_modules/vuetify/types/lib.d.ts" />
-
 import Vue from 'vue';
 import {
   VDatePicker,

--- a/dashboard/routes/overview/Index.vue
+++ b/dashboard/routes/overview/Index.vue
@@ -1,9 +1,4 @@
 <script lang="ts">
-/* eslint-disable vue/valid-v-slot, @typescript-eslint/triple-slash-reference, spaced-comment */
-/// <reference path="../../../node_modules/vue-apollo/types/vue.d.ts" />
-/* eslint-disable vue/valid-v-slot, @typescript-eslint/triple-slash-reference, spaced-comment */
-/// <reference path="../../../node_modules/vue-meta/types/vue.d.ts" />
-
 import Vue from 'vue';
 import { DataTableHeader } from 'vuetify';
 import gql from 'graphql-tag';


### PR DESCRIPTION
- Removes `<reference path ... />` comments from atop various files. This was done to help the VSCode extension Vetur find declaration files, particularly ones that did module augmentation. But it turns out that, if you make `dot` the only repo open in VSCode, Vetur has no trouble finding and interpreting the declaration files.
- Uses an alternate syntax for dynamic slots suggested [here](https://stackoverflow.com/questions/61344980/v-slot-directive-doesnt-support-any-modifier). This is to avoid an ESLint error.