### PR TITLE
Revert "Revert "Fix: docker failure on M1 macs""

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:12-alpine
 LABEL maintainer="Texas Tribune <tech@texastribune.org>"
 
 # add bash for dev
-RUN apk add --no-cache bash
+RUN apk add --no-cache bash python2 g++ make
 
 RUN mkdir /app
 WORKDIR /app


### PR DESCRIPTION
#### What's this PR do?

Reverts a [previous revert](https://github.com/texastribune/dot/pull/118) of [a PR that fixed a docker build issue](https://github.com/texastribune/dot/pull/117) that was merged to master. In other words, this PR restores PR #118.

#### Why are we doing this? How does it help us?

After it was merged to master, PR #117 seemingly caused the failure of a Tribune rundeck job that updates a spreadsheet each day with stats from our database. However, after discussion among the Tribune's engineering team, it remains unclear why that merge would have caused that rundeck job to fail. We theorize that the rundeck job's failure – while still mysterious – may have been a coincidence.

#### How should this be manually tested?

#### How should this change be communicated to end users?

#### Are there any smells or added technical debt to note?

#### What are the relevant tickets?

#### Have you done the following, if applicable:

**_(optional: add explanation between parentheses)_**

- [ ] Added automated tests? _( )_
- [ ] Tested manually on mobile? _( )_
- [ ] Checked BrowserStack? _( )_
- [ ] Checked for performance implications? _( )_
- [ ] Checked accessibility? _( )_
- [ ] Checked for security implications? _( )_
- [ ] Updated the documentation/wiki? _( )_

#### TODOs / next steps:

- [ ] _your TODO here_
